### PR TITLE
Added email-addresses file to configure default root email address.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Role Variables
 --------------
 
     exim4_sender_hostname: 'ubuntu-server'
+    exim4_sender_root_address: 'root@ubuntu-server'
 
 Example Playbook
 ----------------
@@ -15,7 +16,7 @@ Including an example of how to use your role (for instance, with variables passe
 
     - hosts: servers
       roles:
-         - { role: webbylab.exim4-sender, exim4_sender_hostname: 'myserver' }
+         - { role: webbylab.exim4-sender, exim4_sender_hostname: 'myserver', exim4_sender_hostname: 'mail@example.com' }
 
 License
 -------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 exim4_sender_hostname: 'ubuntu-server'
+exim4_sender_root_address: 'root@ubuntu-server'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,6 +15,11 @@
   template: src=mailname.j2 dest=/etc/mailname
   notify:
     - restart exim4
+    
+- name: Update email-addresses file
+  template: src=email-addresses.j2 dest=/etc/email-addresses
+  notify:
+    - restart exim4
 
 - name: Start Exim4 Service
   service: name=exim4 state=started enabled=true

--- a/templates/email-addresses.j2
+++ b/templates/email-addresses.j2
@@ -1,0 +1,10 @@
+# This is /etc/email-addresses. It is part of the exim package
+#
+# This file contains email addresses to use for outgoing mail. Any local
+# part not in here will be qualified by the system domain as normal.
+#
+# It should contain lines of the form:
+#
+#user: someone@isp.com
+#otheruser: someoneelse@anotherisp.com
+root: {{exim4_sender_root_address}}


### PR DESCRIPTION
When setting up exim it's possible to set a custom email address for root. Doing so means that by default when email is sent this address will be used, otherwise when sending the from address will be:

root@{{exim4_sender_hostname}}

I've added in the option to set the root address so the default from address can be customised.
