### PR TITLE
use sudo so ansible does not need to login as root

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,6 +1,8 @@
 ---
 - name: run update-exim4.conf
   command: update-exim4.conf
+  sudo: true
 
 - name: restart exim4
   service: name=exim4 state=restarted
+  sudo: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,17 +4,21 @@
   with_items:
      - exim4-daemon-light
      - mailutils
+  sudo: true
 
 - name: Create update-exim4.conf configuration file
   template: src=update-exim4.conf.conf.j2 dest=/etc/exim4/update-exim4.conf.conf
   notify:
     - run update-exim4.conf
     - restart exim4
+  sudo: true
 
 - name: Update mailname file
   template: src=mailname.j2 dest=/etc/mailname
   notify:
     - restart exim4
+  sudo: true
 
 - name: Start Exim4 Service
   service: name=exim4 state=started enabled=true
+  sudo: true


### PR DESCRIPTION
Use sudo for all tasks to let the role work on cloud servers or other
hosts where remote login as root is not enabled.
